### PR TITLE
Catch error during serialization

### DIFF
--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -106,23 +106,28 @@ final class Utilities
         }
 
         foreach ($obj as $key => $val) {
-            if (is_object($val)) {
-                $val = self::serializeObject(
-                    $val,
-                    $customKeys,
-                    $objectHashes,
-                    $maxDepth,
-                    $depth
-                );
-            } elseif (is_array($val)) {
-                $val = self::serializeForRollbar(
-                    $val,
-                    $customKeys,
-                    $objectHashes,
-                    $maxDepth,
-                    $depth+1
-                );
+            try {
+                if (is_object($val)) {
+                    $val = self::serializeObject(
+                        $val,
+                        $customKeys,
+                        $objectHashes,
+                        $maxDepth,
+                        $depth
+                    );
+                } elseif (is_array($val)) {
+                    $val = self::serializeForRollbar(
+                        $val,
+                        $customKeys,
+                        $objectHashes,
+                        $maxDepth,
+                        $depth+1
+                    );
+                }
+            } catch (\Throwable $e) {
+                $val = 'Error during serialization: '.$e->getMessage();
             }
+
             
             if ($customKeys !== null && in_array($key, $customKeys)) {
                 $returnVal[$key] = $val;


### PR DESCRIPTION
## Description of the change

In some case ... payload has some data which are corrupted. When payload is serialized an error occured. I guess the first goal of rollbar is there to log data to rollbar, even if some data of payload cannot be serialized.

My case:

```
Context:

I have 2 entities (doctrines)

User -> Medias
Medias has a property with an enum status: [inprogress, done]
```

Call:

```
Get user #1 with n Medias. One of theses medias has a bad enum status (foo for example).
I get a ValueError saying my enum is invalid since it does not respect the cases.
```

Easy for rollbar .... but in the payload of my data sent to rollbar, I have the Doctrine PersistentCollection (related to call user->medias). And when this iterator is serialized, it retry to create my object with a bad enum. Doctrine never created this object and rollbar cannot detect this error.

With this PR, i'll only got a message saying data cannot be serialized
Without I get a 500 and **no logs to rollbar**.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)